### PR TITLE
fix migration scripts

### DIFF
--- a/src/database/migrations/20210811150739_user_email_preferences.js
+++ b/src/database/migrations/20210811150739_user_email_preferences.js
@@ -2,7 +2,7 @@ const {USER_EMAIL_PREFERENCES_TABLE} = require("./../../constants/DBTables");
 
 exports.up = (knex) => knex.schema.createTable(USER_EMAIL_PREFERENCES_TABLE, table => {
     table.increments();
-    table.integer("user_id") // If you are running this locally, use integer instead of biginterger
+    table[process.env.NODE_ENV === 'local' ? 'integer' : 'biginteger']("user_id") // If you are running this locally, use integer instead of biginterger
         .index()
         .notNullable()
         .unique()

--- a/src/database/migrations/20210908125234_collectable_user_id.js
+++ b/src/database/migrations/20210908125234_collectable_user_id.js
@@ -2,7 +2,7 @@ const {COLLECTIBLES_TABLE} = require("../../constants/DBTables");
 
 exports.up = (knex) =>
   knex.schema.alterTable(COLLECTIBLES_TABLE, (table) => {
-    table.biginteger("user_id") // If you are running this locally, use integer instead of biginterger
+    table[process.env.NODE_ENV === 'local' ? 'integer' : 'biginteger']("user_id") // If you are running this locally, use integer instead of biginterger
         .unsigned()
         .references("users.id")
         .onUpdate('CASCADE')

--- a/src/database/migrations/20211007144013_fallback_worker_consignment_event_block_tracker.js
+++ b/src/database/migrations/20211007144013_fallback_worker_consignment_event_block_tracker.js
@@ -2,7 +2,7 @@ const { FALLBACK_WORKER_CONSIGNMENT_EVENT_BLOCK_TRACKER_TABLE } = require("./../
 
 exports.up = (knex) => knex.schema.createTable(FALLBACK_WORKER_CONSIGNMENT_EVENT_BLOCK_TRACKER_TABLE, table => {
   table.increments();
-  table.integer("consignment_id") // If you are running this locally, use integer instead of biginterger
+  table.integer("consignment_id")
     .index()
     .unique()
     .notNullable()

--- a/src/database/migrations/20211025130932_secondary_market_listings.js
+++ b/src/database/migrations/20211025130932_secondary_market_listings.js
@@ -31,7 +31,7 @@ exports.up = (knex) => knex.schema.createTable(SECONDARY_MARKET_LISTINGS, table 
       .unsigned()
       .unique()
       .index();
-    table.biginteger("user_id") // If you are running this locally, use integer instead of biginterger
+    table[process.env.NODE_ENV === 'local' ? 'integer' : 'biginteger']("user_id") // If you are running this locally, use integer instead of biginterger
       .unsigned()
       .references("users.id")
       .onUpdate('CASCADE')


### PR DESCRIPTION
When running the migration scripts locally, I was unable to get past errors without tweaking the migration scripts manually. after a bit of trial and error, I found the comments that state that integer should be used instead of biginteger when running locally.

after this change, the env file that is used must have NODE_ENV set to "local" for the migration scripts to work without interference